### PR TITLE
fix py311 | use dataclasses.field(default_factory=...)

### DIFF
--- a/jax_md/rigid_body.py
+++ b/jax_md/rigid_body.py
@@ -704,7 +704,7 @@ class RigidPointUnion:
   point_count: Array
   point_offset: Array
   point_species: Optional[Array] = None
-  point_radius: float = f32(0.5)
+  point_radius: float = dataclasses.dataclasses.field(default_factory=lambda: f32(0.5))
 
   def dimension(self) -> int:
     """Returns the spatial dimension of the shape."""


### PR DESCRIPTION
Fix new dataclass behavior in python 3.11 by using the `default_factory` machinery for mutable default values.

I tested this for my use case on python 3.11 and 3.10, but I didn't find instructions how to run the test suite.

Closes https://github.com/jax-md/jax-md/issues/260

Closes https://github.com/jax-md/jax-md/issues/225