### PR TITLE
Quick fix to e3nn import

### DIFF
--- a/jax_md/_nn/e3nn_layer.py
+++ b/jax_md/_nn/e3nn_layer.py
@@ -211,7 +211,7 @@ from typing import Optional
 from e3nn_jax import Irreps
 from e3nn_jax import IrrepsArray
 from e3nn_jax import FunctionalLinear
-from e3nn_jax import FunctionalFullyConnectedTensorProduct
+from e3nn_jax.legacy import FunctionalFullyConnectedTensorProduct
 
 import flax.linen as nn
 


### PR DESCRIPTION
This PR fixes the import for e3nn-jax  `FunctionalFullyConnectedTensorProduct` mentioned in issue #268.