### PR TITLE
Fix compilation of docs + fix FIRE

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/docs/jax_md.nn.rst
+++ b/docs/jax_md.nn.rst
@@ -34,6 +34,7 @@ how the BP-NN works.
 
 .. [#nongnuch13] Artrith, Nongnuch, Björn Hiller, and Jörg Behler. "Neural network potentials for metals and oxides–First applications to copper clusters at zinc oxide." Physica Status Solidi (b) 250.6 (2013): 1191-1203.
 
+.. currentmodule:: jax_md._nn.behler_parrinello
 .. autofunction:: radial_symmetry_functions
 .. autofunction:: radial_symmetry_functions_neighbor_list
 
@@ -42,6 +43,7 @@ how the BP-NN works.
 
 Graph Neural Networks
 ----------------------
+.. currentmodule:: jax_md.nn
 
 JAX MD also contains primitives for constructing graph neural networks. These 
 primitives are based on (and are one-to-one with) the excellent Jraph library

--- a/docs/jax_md.quantity.rst
+++ b/docs/jax_md.quantity.rst
@@ -29,4 +29,4 @@ Physical Properties
 Data Types
 -----------
 
-.. autoclass:: PhopState
+.. autoclass:: PHopState

--- a/jax_md/elasticity.py
+++ b/jax_md/elasticity.py
@@ -354,25 +354,32 @@ def tensor_to_mandel(T: Array) -> Array:
 
   If mandel_index(i,j) performs the above index mapping, then the input T and
   output M satisfy
+
     M[mandel_index(i,j)] = T[i,j] * w
+
   or
+
     M[mandel_index(i,j), mandel_index(k,l)] = T[i,j,k,l] * w(i,j) * w(k,l)
+
   where
+
     w(i,j) = 1       if i==j
            = sqrt(2) if i!=j
+
   is a weight that is used to ensure proper contraction rules. Here (and only
   here) we do not assume major symmetries in fourth-rank tensors.
 
   Args:
     T: Array with 4 possible shapes:
-      1. T.shape == (2,2)
+
+      #. T.shape == (2,2)
          Convert a symmetric array of shape (2,2) to an array of shape (3,)
-      2. T.shape == (3,3)
+      #. T.shape == (3,3)
          Convert a symmetric array of shape (3,3) to an array of shape (6,)
-      3. T.shape == (2,2,2,2)
+      #. T.shape == (2,2,2,2)
          Convert a tensor of shape (2,2,2,2) with minor symmetries to an array
          of shape (3,3)
-      4. T.shape == (3,3,3,3)
+      #. T.shape == (3,3,3,3)
          Convert a tensor of shape (3,3,3,3) with minor symmetries to an array
          of shape (6,6)
 
@@ -531,23 +538,28 @@ def extract_isotropic_moduli(C: Array) -> Dict:
 
   Bulk modulus, B:
   This is the response to the rotationally invariant strain tensor:
+
       e = (1/2) * ( 1 0 )     or      e = (1/3) * ( 1 0 0 )
                   ( 0 1 )                         ( 0 1 0 )
                                                   ( 0 0 1 )
 
   Shear modulus, G:
   This is the response to the strain tensor:
+
       e = (1/2) * ( 0 1 )     or      e = (1/2) * ( 0 1 0 )
                   ( 1 0 )                         ( 1 0 0 )
                                                   ( 0 0 0 )
+
   averaged over all possible orientations. For perfectly isotropic
   systems, it should be equal to C[0,1,0,1].
 
   Longitudinal modulus, M:
   This is the response to the strain tensor:
+
       e = ( 1 0 )     or      e = ( 1 0 0 )
           ( 0 0 )                 ( 0 0 0 )
                                   ( 0 0 0 )
+
   averaged over all possible orientations. For perfectly isotropic
   systems, it should be equal to C[0,0,0,0].
 

--- a/jax_md/minimize.py
+++ b/jax_md/minimize.py
@@ -109,6 +109,14 @@ class FireDescentState:
   alpha: float
   n_pos: int
 
+  @property
+  def velocity(self):
+      return self.momentum / self.mass
+
+  @property
+  def acceleration(self):
+      return self.force / self.mass
+
 
 def fire_descent(energy_or_force: Callable[..., Array],
                  shift_fn: ShiftFn,
@@ -166,41 +174,33 @@ def fire_descent(energy_or_force: Callable[..., Array],
   def apply_fn(state: FireDescentState, **kwargs) -> FireDescentState:
     state = nve_step_fn(state, dt=state.dt, **kwargs)
     R, P, F, M, dt, alpha, n_pos = dataclasses.unpack(state)
+    V = state.velocity
 
-    # NOTE(schsam): This will be wrong if F_norm ~< 1e-8.
-    # TODO(schsam): We should check for forces below 1e-6. @ErrorChecking
     F_norm = jnp.sqrt(tree_reduce(lambda accum, f:
-                                  accum + jnp.sum(f ** 2) + 1e-6, F, 0.0))
+                                  accum + jnp.sum(f ** 2), F, 0.0))
     P_norm = jnp.sqrt(tree_reduce(lambda accum, p:
                                   accum + jnp.sum(p ** 2), P, 0.0))
 
-    # NOTE: In the original FIRE algorithm, the quantity that determines when
-    # to reset the momenta is F.V rather than F.P. However, all of the JAX MD
-    # simulations are in momentum space for easier agreement with prior work /
-    # rigid body physics. We only use the sign of F.P here, which shouldn't
-    # differ from F.V, however if there are regressions then we should
-    # reconsider this choice.
-    F_dot_P = tree_reduce(
-        lambda accum, f_dot_p: accum + f_dot_p,
-        tree_map(lambda f, p: jnp.sum(f * p), F, P))
+    F_dot_V = tree_reduce(
+        lambda accum, f_dot_v: accum + f_dot_v,
+        tree_map(lambda f, v: jnp.sum(f * v), F, V))
     P = tree_map(lambda p, f: p + alpha * (f * P_norm / F_norm - p), P, F)
 
-    # NOTE(schsam): Can we clean this up at all?
-    n_pos = jnp.where(F_dot_P >= 0, n_pos + 1, 0)
+    n_pos = jnp.where(F_dot_V >= 0, n_pos + 1, 0)
     dt_choice = jnp.array([dt * f_inc, dt_max])
-    dt = jnp.where(F_dot_P > 0,
+    dt = jnp.where(F_dot_V > 0,
                    jnp.where(n_pos > n_min,
                              jnp.min(dt_choice),
                              dt),
                    dt)
-    dt = jnp.where(F_dot_P < 0, dt * f_dec, dt)
-    alpha = jnp.where(F_dot_P > 0,
+    dt = jnp.where(F_dot_V < 0, dt * f_dec, dt)
+    alpha = jnp.where(F_dot_V > 0,
                       jnp.where(n_pos > n_min,
                                 alpha * f_alpha,
                                 alpha),
                       alpha)
-    alpha = jnp.where(F_dot_P < 0, alpha_start, alpha)
-    P = tree_map(lambda p: (F_dot_P >= 0) * p, P)
+    alpha = jnp.where(F_dot_V < 0, alpha_start, alpha)
+    P = tree_map(lambda p: (F_dot_V >= 0) * p, P)
 
-    return FireDescentState(R, P, F, M, dt, alpha, n_pos)  # pytype: disable=wrong-arg-count
+    return FireDescentState(R, P, F, M, dt, alpha, n_pos)
   return init_fn, apply_fn

--- a/jax_md/rigid_body.py
+++ b/jax_md/rigid_body.py
@@ -334,7 +334,10 @@ def conjugate_momentum_to_angular_momentum(orientation: Quaternion,
 
   Simulations involving quaternions typically proceed by integrating Hamilton's
   equations with an extended Hamiltonian,
+
+  .. math::
     H(p, q) = 1/8 p^T S(q) D S(q)^T p + \phi(q)
+
   where q is the orientation and p is the conjugate momentum variable.
   Note (!!) unlike in problems involving only positional degrees of freedom, it
   is not the case here that dq/dt = p / m. The conjugate momentum is defined

--- a/tests/minimize_test.py
+++ b/tests/minimize_test.py
@@ -142,7 +142,7 @@ class DynamicsTest(test_util.JAXMDTestCase):
       Consider three particles with masses [inf, inf, 1.0] and two springs connecting them with rest length 1.0.
       (inf) -- (inf) -- (1.0)
       The initial positions are [0.0, 0.5, 1.0]. After optimization, the positions should be [0.0, 0.5, 1.5].
-      In two dimensions, the y coordinates are set to 0.
+      In other dimensions, the coordinates are set to 0 and should remain so.
       '''
       N = 3
       bond = jnp.array([[0, 1], [1, 2]])

--- a/tests/minimize_test.py
+++ b/tests/minimize_test.py
@@ -30,6 +30,7 @@ from jax_md import minimize
 from jax_md import quantity
 from jax_md.util import *
 from jax_md import test_util
+from jax_md.energy import simple_spring_bond
 
 jax_config.parse_flags_with_absl()
 FLAGS = jax_config.FLAGS
@@ -129,6 +130,44 @@ class DynamicsTest(test_util.JAXMDTestCase):
         assert dr_new.dtype == dtype
         E_current = E_new
         dr_current = dr_new
+
+  @parameterized.named_parameters(test_util.cases_from_list(
+      {
+          'testcase_name': '_dim={}_dtype={}'.format(dim, dtype.__name__),
+          'spatial_dimension': dim,
+          'dtype': dtype
+      } for dim in SPATIAL_DIMENSION for dtype in DTYPE))
+  def test_fire_descent_with_unmoving_masses(self, spatial_dimension, dtype):
+      '''
+      Consider three particles with masses [inf, inf, 1.0] and two springs connecting them with rest length 1.0.
+      (inf) -- (inf) -- (1.0)
+      The initial positions are [0.0, 0.5, 1.0]. After optimization, the positions should be [0.0, 0.5, 1.5].
+      In two dimensions, the y coordinates are set to 0.
+      '''
+      N = 3
+      bond = jnp.array([[0, 1], [1, 2]])
+      R_init = jnp.zeros(shape=(N, spatial_dimension), dtype=dtype)
+      R_init = R_init.at[1, 0].set(0.5)
+      R_init = R_init.at[2, 0].set(1.0)
+      mass = jnp.array([jnp.inf, jnp.inf, 1.0], dtype=dtype)
+      iterations = 10000
+
+      displacement_fn, shift_fn = space.free()
+      energy_fn = simple_spring_bond(displacement_fn, bond=bond, length=1.0)
+
+      init_fn, apply_fn = minimize.fire_descent(energy_fn, shift_fn=shift_fn, dt_start=0.001, dt_max=0.1)
+
+      state = init_fn(R_init, mass=mass)
+      body_fun = lambda i, state: apply_fn(state)
+      state = lax.fori_loop(0, iterations, body_fun, state)
+      R = state.position
+
+      # Check x-coordinates: should be (0, 0.5, 1.5)
+      self.assertAllClose(R[:, 0], np.array([0.0, 0.5, 1.5], dtype=dtype))
+
+      # Check other coordinates: should be all zeros
+      self.assertAllClose(R[:, 1:], np.zeros(shape=(N, spatial_dimension-1), dtype=dtype))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
## Compilation of code
The compilation of docs has been fixed. The main problem was that Python 3.7 was used, which is not supported by JAX anymore.
https://testjaxmddoc.readthedocs.io/en/latest/
This should address #261 and #279.

## FIRE descent
In addition, I fixed a problem with FIRE descent, which should address #264. FIRE did not handle infinite masses well. I have created a new Python test to address this (minimize_test.py test_fire_descent_with_unmoving_masses). Consider three masses connected by two springs with rest length 1.
`(inf) -- (inf) -- (1.0)`
The first two masses will not move, but the last one can. 
`Initial positions: [0.0, 0.5, 1.0]`
`After optimization. before the fix: [0.0, 0.5, 1.4866375]`
`After optimization. after the fix: [0.0, 0.5, 1.5]`
The correct value for the last mass is 1.5 because then its distance to the second mass is 1.
