### PR TITLE
Fix compilation of docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/docs/jax_md.nn.rst
+++ b/docs/jax_md.nn.rst
@@ -34,6 +34,7 @@ how the BP-NN works.
 
 .. [#nongnuch13] Artrith, Nongnuch, Björn Hiller, and Jörg Behler. "Neural network potentials for metals and oxides–First applications to copper clusters at zinc oxide." Physica Status Solidi (b) 250.6 (2013): 1191-1203.
 
+.. currentmodule:: jax_md._nn.behler_parrinello
 .. autofunction:: radial_symmetry_functions
 .. autofunction:: radial_symmetry_functions_neighbor_list
 
@@ -42,6 +43,7 @@ how the BP-NN works.
 
 Graph Neural Networks
 ----------------------
+.. currentmodule:: jax_md.nn
 
 JAX MD also contains primitives for constructing graph neural networks. These 
 primitives are based on (and are one-to-one with) the excellent Jraph library

--- a/docs/jax_md.quantity.rst
+++ b/docs/jax_md.quantity.rst
@@ -29,4 +29,4 @@ Physical Properties
 Data Types
 -----------
 
-.. autoclass:: PhopState
+.. autoclass:: PHopState

--- a/jax_md/elasticity.py
+++ b/jax_md/elasticity.py
@@ -354,25 +354,32 @@ def tensor_to_mandel(T: Array) -> Array:
 
   If mandel_index(i,j) performs the above index mapping, then the input T and
   output M satisfy
+
     M[mandel_index(i,j)] = T[i,j] * w
+
   or
+
     M[mandel_index(i,j), mandel_index(k,l)] = T[i,j,k,l] * w(i,j) * w(k,l)
+
   where
+
     w(i,j) = 1       if i==j
            = sqrt(2) if i!=j
+
   is a weight that is used to ensure proper contraction rules. Here (and only
   here) we do not assume major symmetries in fourth-rank tensors.
 
   Args:
     T: Array with 4 possible shapes:
-      1. T.shape == (2,2)
+
+      #. T.shape == (2,2)
          Convert a symmetric array of shape (2,2) to an array of shape (3,)
-      2. T.shape == (3,3)
+      #. T.shape == (3,3)
          Convert a symmetric array of shape (3,3) to an array of shape (6,)
-      3. T.shape == (2,2,2,2)
+      #. T.shape == (2,2,2,2)
          Convert a tensor of shape (2,2,2,2) with minor symmetries to an array
          of shape (3,3)
-      4. T.shape == (3,3,3,3)
+      #. T.shape == (3,3,3,3)
          Convert a tensor of shape (3,3,3,3) with minor symmetries to an array
          of shape (6,6)
 
@@ -531,23 +538,28 @@ def extract_isotropic_moduli(C: Array) -> Dict:
 
   Bulk modulus, B:
   This is the response to the rotationally invariant strain tensor:
+
       e = (1/2) * ( 1 0 )     or      e = (1/3) * ( 1 0 0 )
                   ( 0 1 )                         ( 0 1 0 )
                                                   ( 0 0 1 )
 
   Shear modulus, G:
   This is the response to the strain tensor:
+
       e = (1/2) * ( 0 1 )     or      e = (1/2) * ( 0 1 0 )
                   ( 1 0 )                         ( 1 0 0 )
                                                   ( 0 0 0 )
+
   averaged over all possible orientations. For perfectly isotropic
   systems, it should be equal to C[0,1,0,1].
 
   Longitudinal modulus, M:
   This is the response to the strain tensor:
+
       e = ( 1 0 )     or      e = ( 1 0 0 )
           ( 0 0 )                 ( 0 0 0 )
                                   ( 0 0 0 )
+
   averaged over all possible orientations. For perfectly isotropic
   systems, it should be equal to C[0,0,0,0].
 

--- a/jax_md/rigid_body.py
+++ b/jax_md/rigid_body.py
@@ -334,7 +334,10 @@ def conjugate_momentum_to_angular_momentum(orientation: Quaternion,
 
   Simulations involving quaternions typically proceed by integrating Hamilton's
   equations with an extended Hamiltonian,
+
+  .. math::
     H(p, q) = 1/8 p^T S(q) D S(q)^T p + \phi(q)
+
   where q is the orientation and p is the conjugate momentum variable.
   Note (!!) unlike in problems involving only positional degrees of freedom, it
   is not the case here that dq/dt = p / m. The conjugate momentum is defined


### PR DESCRIPTION
The compilation of docs has been fixed. The main problem was that Python 3.7 was used, which is not supported by JAX anymore.
https://testjaxmddoc.readthedocs.io/en/latest/
This should address #261 and #279.