### PR TITLE
Slightly update cookbook notebook to work with recent JAX versions.

### DIFF
--- a/notebooks/jax_md_cookbook.ipynb
+++ b/notebooks/jax_md_cookbook.ipynb
@@ -21,7 +21,7 @@
       "cell_type": "markdown",
       "metadata": {
         "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text"	
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/google/jax-md/blob/main/notebooks/jax_md_cookbook.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -58,7 +58,7 @@
         "#@title Imports & Utils\n",
         "!pip install -q git+https://www.github.com/google/jax-md\n",
         "\n",
-        "import time \n",
+        "import time\n",
         "\n",
         "from functools import partial\n",
         "import numpy as onp\n",
@@ -73,8 +73,8 @@
         "from jax import random\n",
         "from jax import lax\n",
         "\n",
-        "from jax.experimental import stax\n",
-        "from jax.experimental import optimizers\n",
+        "from jax.example_libraries import stax\n",
+        "from jax.example_libraries import optimizers\n",
         "\n",
         "from jax.config import config\n",
         "config.update('jax_enable_x64', True)\n",
@@ -105,17 +105,17 @@
         "import matplotlib\n",
         "import matplotlib.pyplot as plt\n",
         "import seaborn as sns\n",
-        "  \n",
+        "\n",
         "sns.set_style(style='white')\n",
         "sns.set(font_scale=1.6)\n",
         "\n",
-        "def format_plot(x, y):  \n",
+        "def format_plot(x, y):\n",
         "  plt.xlabel(x, fontsize=20)\n",
         "  plt.ylabel(y, fontsize=20)\n",
-        "  \n",
+        "\n",
         "def finalize_plot(shape=(1, 1)):\n",
         "  plt.gcf().set_size_inches(\n",
-        "    shape[0] * 1.5 * plt.gcf().get_size_inches()[1], \n",
+        "    shape[0] * 1.5 * plt.gcf().get_size_inches()[1],\n",
         "    shape[1] * 1.5 * plt.gcf().get_size_inches()[1])\n",
         "  plt.tight_layout()\n",
         "\n",
@@ -125,16 +125,17 @@
         "def draw_system(R, box_size, marker_size, color=None):\n",
         "  if color == None:\n",
         "    color = [64 / 256] * 3\n",
+        "  color = onp.array(color)\n",
         "  ms = marker_size / box_size\n",
         "\n",
         "  R = onp.array(R)\n",
         "\n",
         "  marker_style = dict(\n",
-        "      linestyle='none', \n",
+        "      linestyle='none',\n",
         "      markeredgewidth=3,\n",
-        "      marker='o', \n",
-        "      markersize=ms, \n",
-        "      color=color, \n",
+        "      marker='o',\n",
+        "      markersize=ms,\n",
+        "      color=color,\n",
         "      fillstyle='none')\n",
         "\n",
         "  plt.plot(R[:, 0], R[:, 1], **marker_style)\n",
@@ -187,7 +188,7 @@
         "2. Using neural networks to learn an energy function.\n",
         "5. Meta-optimization through simulation to identify physical parameters that lead to frustration.\n",
         "\n",
-        "While these examples are designed to be illustrative, they are similar to problems faced in actual research. Aside from the first case, each of these examples would be arduous using existing tools. \n"
+        "While these examples are designed to be illustrative, they are similar to problems faced in actual research. Aside from the first case, each of these examples would be arduous using existing tools.\n"
       ]
     },
     {
@@ -228,15 +229,15 @@
         "from jax_md import quantity\n",
         "\n",
         "N = 256\n",
-        "box_size = quantity.box_size_at_number_density(particle_count=N, \n",
-        "                                               number_density=1, \n",
+        "box_size = quantity.box_size_at_number_density(particle_count=N,\n",
+        "                                               number_density=1,\n",
         "                                               spatial_dimension=2)\n",
         "\n",
         "r = square_lattice(N, box_size)\n",
         "draw_system(r, box_size, 270.0)\n",
         "finalize_plot((0.75, 0.75))"
       ],
-      "execution_count": 2,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -283,7 +284,7 @@
         "\n",
         "finalize_plot((1.5, 0.75))"
       ],
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -322,7 +323,7 @@
         "\n",
         "displacement_fn, shift_fn = space.periodic(box_size)"
       ],
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -335,7 +336,7 @@
         "\n",
         "$$\n",
         "U(r_{ij}) = \\begin{cases}\n",
-        "  (1 - r_{ij})^2 & \\text{if $r_{ij} < 1$} \\\\ \n",
+        "  (1 - r_{ij})^2 & \\text{if $r_{ij} < 1$} \\\\\n",
         "  0 & \\text{if $r_{ij}>1$}\n",
         "  \\end{cases}\n",
         "$$  \n",
@@ -367,7 +368,7 @@
         "\n",
         "format_plot('$r$', '$U(r)$')"
       ],
-      "execution_count": 5,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -408,7 +409,7 @@
         "energy_fn = energy.soft_sphere_pair(displacement_fn)\n",
         "print('Energy of the system, U = {:f}'.format(energy_fn(r)))"
       ],
-      "execution_count": 6,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -429,7 +430,7 @@
         "$$\\frac{d{\\vec r}_i(t)}{dt} = \\vec F_i(t) + \\sqrt{2k_BT}\\vec \\xi_i(t).$$\n",
         "Here $\\vec F_i(t)$ are forces, $\\vec \\xi_i\\sim\\mathcal N(0, 1)$ is i.i.d. Gaussian distributed noise, and $k_BT$ specifies the temperature of the water. Incidentally, this model of objects in water [dates back to Einstein.](http://users.physik.fu-berlin.de/~kleinert/files/eins_brownian.pdf)\n",
         "\n",
-        "To simulate brownian motion we will need to draw the $\\xi_i$ from a Gaussian distribution. In [JAX, random numbers](https://en.wikipedia.org/wiki/Brownian_motion) do not use global state. Instead we have to instantiate the state of random numbers explicitly using `random.PRNGKey(seed)`. \n",
+        "To simulate brownian motion we will need to draw the $\\xi_i$ from a Gaussian distribution. In [JAX, random numbers](https://en.wikipedia.org/wiki/Brownian_motion) do not use global state. Instead we have to instantiate the state of random numbers explicitly using `random.PRNGKey(seed)`.\n",
         "\n"
       ]
     },
@@ -441,7 +442,7 @@
       "source": [
         "key = random.PRNGKey(0)"
       ],
-      "execution_count": 7,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -455,8 +456,7 @@
         "*   `state = init_fn(key, r)` take the state of a random number generator and bubble positions. It returns a simulation state that might contain auxiliary information.\n",
         "*   `state = apply_fn(state)` which increments the simulation by a step.\n",
         "\n",
-        "We can now setup some experimental parameters and create a simulation.\n",
-        " "
+        "We can now setup some experimental parameters and create a simulation.\n"
       ]
     },
     {
@@ -474,7 +474,7 @@
         "\n",
         "init_fn, apply_fn = simulate.brownian(energy_fn, shift_fn, dt, temperature)"
       ],
-      "execution_count": 8,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -494,7 +494,7 @@
       "source": [
         "apply_fn = jit(apply_fn)"
       ],
-      "execution_count": 9,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -527,7 +527,7 @@
         "\n",
         "trajectory = np.stack(trajectory)"
       ],
-      "execution_count": 10,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -567,7 +567,7 @@
         "draw_system(state.position, box_size, 270.0)\n",
         "finalize_plot((0.75, 0.75))"
       ],
-      "execution_count": 11,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -621,7 +621,7 @@
         "    resolution=(512, 512)\n",
         ")"
       ],
-      "execution_count": 12,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1700,11 +1700,11 @@
         "id": "JE5AGNuIaLCy"
       },
       "source": [
-        "Improvements to processing power are increasingly due to device parallelism rather compute speed. This parallelism is often used to simulate increasingly large systems. However, there are other interesting uses of parallelism that have recieved less attention. Many of these methods (e.g. [replica exchange MCMC sampling](https://en.wikipedia.org/wiki/Parallel_tempering)) involve simulating an entire ensemble of states simultaneously. \n",
+        "Improvements to processing power are increasingly due to device parallelism rather compute speed. This parallelism is often used to simulate increasingly large systems. However, there are other interesting uses of parallelism that have recieved less attention. Many of these methods (e.g. [replica exchange MCMC sampling](https://en.wikipedia.org/wiki/Parallel_tempering)) involve simulating an entire ensemble of states simultaneously.\n",
         "\n",
         "Thanks to JAX, ensembling can be done automatically in JAX MD. For small systems, the amount of necessary compute can be sub-linear in the number of replicas since it can otherwise be difficult to saturate the parallelism of accelerators. Here we go through an example where we use automatic ensembling to quickly compute statistics of a simulation.\n",
         "\n",
-        "We will set up a function that takes a random key and a temperature. The function will use the key to initialize a bubble raft (see the warmup) and simulate it for some time at the given temperature. We will then return the positions of the bubbles. To begin with, however, we will define some aspects of the simulation that will stay fixed across members of the ensemble. "
+        "We will set up a function that takes a random key and a temperature. The function will use the key to initialize a bubble raft (see the warmup) and simulate it for some time at the given temperature. We will then return the positions of the bubbles. To begin with, however, we will define some aspects of the simulation that will stay fixed across members of the ensemble."
       ]
     },
     {
@@ -1718,14 +1718,14 @@
         "simulation_steps = np.arange(1000)\n",
         "key = random.PRNGKey(0)\n",
         "\n",
-        "box_size = quantity.box_size_at_number_density(particle_count=N, \n",
+        "box_size = quantity.box_size_at_number_density(particle_count=N,\n",
         "                                               number_density=1,\n",
         "                                               spatial_dimension=2)\n",
         "displacement, shift = space.periodic(box_size)\n",
         "\n",
         "energy_fn = energy.soft_sphere_pair(displacement)"
       ],
-      "execution_count": 13,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -1756,7 +1756,7 @@
         "\n",
         "  return state.position"
       ],
-      "execution_count": 14,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -1784,7 +1784,7 @@
         "draw_system(bubble_positions, box_size, 190)\n",
         "finalize_plot((0.5, 0.5))"
       ],
-      "execution_count": 15,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1828,7 +1828,7 @@
         "# We only want to vectorize over the keys which we denote by in_axis=(0, None).\n",
         "vectorized_simulation = vmap(simulation, in_axes=(0, None))"
       ],
-      "execution_count": 16,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -1863,7 +1863,7 @@
         "\n",
         "finalize_plot((1.5, 1.5))"
       ],
-      "execution_count": 17,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1919,7 +1919,7 @@
         "plt.plot(bins[:-1] * 10 ** 5, counts, 'o')\n",
         "format_plot('$E\\\\times 10 ^{-5}$', '$P(E)$')"
       ],
-      "execution_count": 18,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1942,7 +1942,7 @@
         "id": "q3tdSxTIFBwJ"
       },
       "source": [
-        "So far we have vectorized the simulation over only the random key. Another experiment that we can run is to vectorize separately over the key and the temperature. In this way we can run an experiment where we look at how the distribution of energies changes with temperature using a single call to the simulation. We use this to plot the mean and variance of energy as a function of temperature. "
+        "So far we have vectorized the simulation over only the random key. Another experiment that we can run is to vectorize separately over the key and the temperature. In this way we can run an experiment where we look at how the distribution of energies changes with temperature using a single call to the simulation. We use this to plot the mean and variance of energy as a function of temperature."
       ]
     },
     {
@@ -1963,7 +1963,7 @@
         "bubble_positions = double_vectorized_simulation(simulation_keys, temperatures)\n",
         "bubble_energies = double_vectorized_energy(bubble_positions)"
       ],
-      "execution_count": 19,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -1993,7 +1993,7 @@
         "\n",
         "finalize_plot((2, 0.75))"
       ],
-      "execution_count": 20,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2025,7 +2025,7 @@
         "id": "KL6Tq422hhvJ"
       },
       "source": [
-        "A final experiment that we can perform is to measure the time-per-simulation as a function of the number of simulations being vectorized over. We measure this below and plot the result. Because we're trying to get accurate timings for the scaling, this cell can take some time to run. "
+        "A final experiment that we can perform is to measure the time-per-simulation as a function of the number of simulations being vectorized over. We measure this below and plot the result. Because we're trying to get accurate timings for the scaling, this cell can take some time to run."
       ]
     },
     {
@@ -2047,7 +2047,7 @@
         "  simulation_keys = random.split(key, batch_size)\n",
         "\n",
         "  vectorized_simulation(simulation_keys, 1e-5)\n",
-        "  \n",
+        "\n",
         "  start = time.time()\n",
         "  for i in range(n_batches):\n",
         "    rs = vectorized_simulation(simulation_keys, 1e-5)\n",
@@ -2055,7 +2055,7 @@
         "  dt = time.time() - start\n",
         "  dts += [dt]"
       ],
-      "execution_count": 21,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2102,7 +2102,7 @@
         "format_plot('Vectorization Size', 'Secs / Simulation')\n",
         "finalize_plot((1, 0.75))"
       ],
-      "execution_count": 22,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2125,7 +2125,7 @@
         "id": "DyAq0g9Y3r89"
       },
       "source": [
-        "As expected, we see that the time-per-simulation decreases with the number of simulations being performed in parallel. This scaling continues until the GPU becomes saturated. For a V100 GPU this happens at a batch size of about $2048$. "
+        "As expected, we see that the time-per-simulation decreases with the number of simulations being performed in parallel. This scaling continues until the GPU becomes saturated. For a V100 GPU this happens at a batch size of about $2048$."
       ]
     },
     {
@@ -2147,9 +2147,9 @@
         "1.   Simulation code and machine learning code are written in different languages.\n",
         "2.   Due to the lack of automatic differentiation in molecular dynamics packages, including neural network potentials in physics simulations can require substantial work which often prohibits easy experimentation.\n",
         "\n",
-        "To address these issues, several projects developed adapters between common ML languages, like Torch and Tensorflow, and common MD languages like LAMMPS. However, these solutions require researchers to be working in exactly the regime serviced by the adapter. One of the consequences of this is that the atomistic features which get fed into the neural network need to be differentiated by hand within the MD package to compute forces. Trying out a new set of features can easily take weeks or months of work to compute and implement these derivatives. \n",
+        "To address these issues, several projects developed adapters between common ML languages, like Torch and Tensorflow, and common MD languages like LAMMPS. However, these solutions require researchers to be working in exactly the regime serviced by the adapter. One of the consequences of this is that the atomistic features which get fed into the neural network need to be differentiated by hand within the MD package to compute forces. Trying out a new set of features can easily take weeks or months of work to compute and implement these derivatives.\n",
         "\n",
-        "Here, as an example, we will fit a neural network to the bubble potential defined above. We will see that JAX MD gets around these issues easily. We will implement the Behler-Parrinello network in one line of pure python. We will then take gradients through the entire network and features in a single line of code. "
+        "Here, as an example, we will fit a neural network to the bubble potential defined above. We will see that JAX MD gets around these issues easily. We will implement the Behler-Parrinello network in one line of pure python. We will then take gradients through the entire network and features in a single line of code."
       ]
     },
     {
@@ -2186,11 +2186,11 @@
         "\n",
         "bubble_positions = simulation(key, temperature=1e-5)\n",
         "\n",
-        "print('Below is the quenched system.')    \n",
+        "print('Below is the quenched system.')\n",
         "draw_system(bubble_positions, box_size, 250.0)\n",
         "finalize_plot((0.75, 0.75))"
       ],
-      "execution_count": 24,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -2252,7 +2252,7 @@
         "\n",
         "finalize_plot((1.5, 0.75))"
       ],
-      "execution_count": 29,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2275,7 +2275,7 @@
         "id": "udaxOWgJtrBb"
       },
       "source": [
-        "We now briefly describe the Behler-Parrinello architecture. For each bubble, one computes \"features\" which describe its local environment. The features for each bubble is fed into an identical copy of a fully-connected neural network. These per-bubble networks can be thought of as computing the energy of that particular bubble. The total energy, $\\mathcal U$, is then a sum over the outputs of the per-bubble networks. \n",
+        "We now briefly describe the Behler-Parrinello architecture. For each bubble, one computes \"features\" which describe its local environment. The features for each bubble is fed into an identical copy of a fully-connected neural network. These per-bubble networks can be thought of as computing the energy of that particular bubble. The total energy, $\\mathcal U$, is then a sum over the outputs of the per-bubble networks.\n",
         "\n",
         "While there are many different choices of features that achieve reasonable results here we use the [\"radial symmetry function\"](https://en.wikipedia.org/wiki/Radial_distribution_function), $g(r)$, to generate features for simplicity. The radial distribution function measures the density of neighbors a distance $r$ from a central bubble. By using a discrete set of radii, $\\{r_i\\}_{i\\in M}$, we can generate a fixed feature set per-bubble. To do this we use the `pair_correlation` function included in JAX MD. `pair_correlation_fun = pair_correlation(displacement_fun)` creates a function that computes the pair correlation functions each bubble in a raft. We can then sum over the bubbles to compute the total pair correlation function. We create a `pair_correlation_fun` and use compute the pair correlation function for the bubble raft above as well as one of the gaussian distortions."
       ]
@@ -2309,7 +2309,7 @@
         "\n",
         "finalize_plot((1.5, 0.75))"
       ],
-      "execution_count": 54,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -2363,7 +2363,7 @@
         "test_positions = np.array(distorted_positions[no_training_samples:])\n",
         "test_features = vectorized_g(test_positions)"
       ],
-      "execution_count": 55,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -2380,7 +2380,7 @@
         "id": "bOcT0zpzwYuC"
       },
       "source": [
-        "We now define the Behler-Parrinello neural network architecture. To do this we will use [JAX's neural network library](https://github.com/google/jax#neural-net-building-with-stax) called stax. Neural networks in stax defined using components, for example, fully connected layers or activation functions. Components are pairs of functions `(init_fun, apply_fun)`. \n",
+        "We now define the Behler-Parrinello neural network architecture. To do this we will use [JAX's neural network library](https://github.com/google/jax#neural-net-building-with-stax) called stax. Neural networks in stax defined using components, for example, fully connected layers or activation functions. Components are pairs of functions `(init_fun, apply_fun)`.\n",
         "1. `out_shape, params = init_fun(key, in_shape)` initializes the parameters of the component given a random key and an input shape.\n",
         "2. `fxs = apply_fun(params, xs)` evaluates the component given parameters and inputs.\n",
         "\n",
@@ -2400,7 +2400,7 @@
         "    stax.Dense(1))  # readout\n",
         "E = lambda params, features: _E(params, features)"
       ],
-      "execution_count": 56,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -2424,7 +2424,7 @@
         "  return np.mean((E_total - vmap(energy_fn)(positions))**2)\n",
         "grad_loss = grad(loss)"
       ],
-      "execution_count": 57,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -2474,7 +2474,7 @@
         "\n",
         "\n",
         "def batch(key):\n",
-        "  steps_per_epoch = no_training_samples // batch_size \n",
+        "  steps_per_epoch = no_training_samples // batch_size\n",
         "  train_epochs = train_steps // steps_per_epoch\n",
         "  for s in range(train_epochs):\n",
         "    key, split = random.split(key)\n",
@@ -2482,10 +2482,10 @@
         "    positions = train_positions[permutation]\n",
         "    features = train_features[permutation]\n",
         "    for i in range(0, no_training_samples, batch_size):\n",
-        "      batch_data = (positions[permutation[i:i + batch_size]], \n",
+        "      batch_data = (positions[permutation[i:i + batch_size]],\n",
         "                    features[permutation[i:i + batch_size]])\n",
         "      yield batch_data\n",
-        "  \n",
+        "\n",
         "# Precompute the test time energies.\n",
         "test_energies = vmap(energy_fn)(test_positions)\n",
         "\n",
@@ -2505,7 +2505,7 @@
         "    dt = time.time() - t\n",
         "    train_loss = loss(get_params(state), train_positions, train_features)\n",
         "    train_losses += [train_loss]\n",
-        "    \n",
+        "\n",
         "    test_loss = loss(get_params(state), test_positions, test_features)\n",
         "    test_losses += [test_loss]\n",
         "\n",
@@ -2514,7 +2514,7 @@
         "        dt, i, train_loss, test_loss))\n",
         "    t = time.time()"
       ],
-      "execution_count": 58,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -2578,7 +2578,7 @@
         "id": "s-Hh4UaaDhQh"
       },
       "source": [
-        "Now that we've trained the network, we can define a neural network energy that we can use in simulations using a single line. \n"
+        "Now that we've trained the network, we can define a neural network energy that we can use in simulations using a single line.\n"
       ]
     },
     {
@@ -2590,7 +2590,7 @@
         "params = get_params(state)\n",
         "neural_energy_fn = lambda r: np.sum(E(params, g(r)), axis=(0, 1))"
       ],
-      "execution_count": 59,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -2633,7 +2633,7 @@
         "\n",
         "finalize_plot((2, 0.75))\n"
       ],
-      "execution_count": 60,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2656,7 +2656,7 @@
         "id": "1AdVXAbs4ZMR"
       },
       "source": [
-        "Next, let's see how the predicted forces on each particle compares to the correct force. Note that $F_i = -\\frac{dU(x)}{dx_i}$, where $U$ is the potential energy given by our neural network, and $x_i$ are the spatial coordinates of particles. $U(x) = NN(G(x))$, where $NN$ is the neural network and $G(x)$ is the symmetry functions. Thus \n",
+        "Next, let's see how the predicted forces on each particle compares to the correct force. Note that $F_i = -\\frac{dU(x)}{dx_i}$, where $U$ is the potential energy given by our neural network, and $x_i$ are the spatial coordinates of particles. $U(x) = NN(G(x))$, where $NN$ is the neural network and $G(x)$ is the symmetry functions. Thus\n",
         "$$F_i = -\\frac{dNN(G(x))}{dG(x)}\\frac{dG(x)}{dx}.$$\n",
         "$\\frac{dNN(G(x))}{dG(x)}$ is easy to get in most neural network packages, but $\\frac{dG(x)}{dx}$ is often a pain point and has to be coded up by hand. In JAX, MD, we get $\\frac{dG(x)}{dx}$ for free without any extra work. To demonstrate this we will compare the forces computed by the neural network with the true forces. We will measure by computing the cosine-similarity between the two forces, $\\cos\\theta$."
       ]
@@ -2685,7 +2685,7 @@
         "format_plot('$\\\\cos\\\\theta$', '$P(\\\\cos\\\\theta)$')\n",
         "finalize_plot((1, 0.75))"
       ],
-      "execution_count": 61,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2726,9 +2726,9 @@
         "id": "t_yj2rAUTGe_"
       },
       "source": [
-        "So far we have demonstrated how JAX MD can make common workloads easier. However, combining molecular dynamics with automatic differentiation opens the door for qualitatively new research. One such avenue involves differentiating through the simulation trajectory to optimize physical parameters. There have been several excellent applications so far in e.g. [protein folding](https://openreview.net/forum?id=Byg3y3C9Km), but until now this has involved significant amounts of specialized code. This vein of research is also similar to recent work in machine learning on [meta-optimization.](https://arxiv.org/abs/1606.04474) \n",
+        "So far we have demonstrated how JAX MD can make common workloads easier. However, combining molecular dynamics with automatic differentiation opens the door for qualitatively new research. One such avenue involves differentiating through the simulation trajectory to optimize physical parameters. There have been several excellent applications so far in e.g. [protein folding](https://openreview.net/forum?id=Byg3y3C9Km), but until now this has involved significant amounts of specialized code. This vein of research is also similar to recent work in machine learning on [meta-optimization.](https://arxiv.org/abs/1606.04474)\n",
         "\n",
-        "Here we revisit the bubble raft example above. We will show how one can control the structure of the bubble raft by differentiating through the simulation. As we saw, bubble rafts form a hexagonal structure when all of the bubbles have the same size. However, when the bubbles have different sizes the situation can change considerably. To experiment with these changes, we're going to set up a simulation of a bubble raft with bubbles of two distinct sizes. To keep things simple, we'll let half of the bubbles have diameter $1$ and half have diameter $D$. \n",
+        "Here we revisit the bubble raft example above. We will show how one can control the structure of the bubble raft by differentiating through the simulation. As we saw, bubble rafts form a hexagonal structure when all of the bubbles have the same size. However, when the bubbles have different sizes the situation can change considerably. To experiment with these changes, we're going to set up a simulation of a bubble raft with bubbles of two distinct sizes. To keep things simple, we'll let half of the bubbles have diameter $1$ and half have diameter $D$.\n",
         "\n",
         "To control the conditions of the experiment, we will keep the total volume of the bubbles constant. To do this, note that if there are $N$ bubbles then the total volume of water filled by bubbles is,\n",
         "$$V_{\\text{bubbles}} = \\frac N8\\pi(D^2 + 1)$$\n",
@@ -2759,7 +2759,7 @@
         "  bubble_volume = N_2 * np.pi * (diameter ** 2 + 1) / 4\n",
         "  return np.sqrt(bubble_volume / packing_fraction)"
       ],
-      "execution_count": 62,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -2768,7 +2768,7 @@
         "id": "B6MIAeMUUpfi"
       },
       "source": [
-        "Now we write a simulation similar to the one in the Automatic Ensembling section. This time, however, will take a `diameter` in addition to a key. Additionally, unlike in the previous simulations where we only had one kind of bubble, this time we will have two. This is implemented here using the notion of bubble \"species\". We will split our bubble raft into two different species of bubbles that we will label $A$ and $B$ respectively. By having two different \"species\" of bubbles we can define different values of $\\sigma$ for interactions between the different species. Since we have two different species this gives us three different $\\sigma$ to define: $\\sigma_{AA}$, $\\sigma_{AB}$, and $\\sigma_{BB}$. We know that $\\sigma_{AA} = D$ and $\\sigma_{BB} = 1$, but what should $\\sigma_{AB}$ be? Since the $\\sigma$ denote radii, it should be the case that $\\sigma_{AB} = \\frac12(D + 1)$. We can setup a helper function to setup the species now. "
+        "Now we write a simulation similar to the one in the Automatic Ensembling section. This time, however, will take a `diameter` in addition to a key. Additionally, unlike in the previous simulations where we only had one kind of bubble, this time we will have two. This is implemented here using the notion of bubble \"species\". We will split our bubble raft into two different species of bubbles that we will label $A$ and $B$ respectively. By having two different \"species\" of bubbles we can define different values of $\\sigma$ for interactions between the different species. Since we have two different species this gives us three different $\\sigma$ to define: $\\sigma_{AA}$, $\\sigma_{AB}$, and $\\sigma_{BB}$. We know that $\\sigma_{AA} = D$ and $\\sigma_{BB} = 1$, but what should $\\sigma_{AB}$ be? Since the $\\sigma$ denote radii, it should be the case that $\\sigma_{AB} = \\frac12(D + 1)$. We can setup a helper function to setup the species now."
       ]
     },
     {
@@ -2784,11 +2784,11 @@
         "  d_BB = 1\n",
         "  d_AB = 0.5 * (diameter + 1)\n",
         "  return np.array(\n",
-        "      [[d_AA, d_AB], \n",
+        "      [[d_AA, d_AB],\n",
         "       [d_AB, d_BB]]\n",
         "  )"
       ],
-      "execution_count": 63,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -2797,7 +2797,7 @@
         "id": "rD76oJ5evQUP"
       },
       "source": [
-        "We will feed the `species` and `sigma` definitions into the `energy.soft_sphere_pair` function. We will also have our simulation return three things: the box size, the final energy, and the final positions. Unlike the previous simulations, we will minimize the energy of the system instead of simulating using brownian motion. To do this we will use the minimizer, `init_fun, apply_fun = minimize.fire_descent(energy_fun, shift_fun)` provided by JAX MD. "
+        "We will feed the `species` and `sigma` definitions into the `energy.soft_sphere_pair` function. We will also have our simulation return three things: the box size, the final energy, and the final positions. Unlike the previous simulations, we will minimize the energy of the system instead of simulating using brownian motion. To do this we will use the minimizer, `init_fun, apply_fun = minimize.fire_descent(energy_fun, shift_fun)` provided by JAX MD."
       ]
     },
     {
@@ -2828,7 +2828,7 @@
         "\n",
         "  return box_size, energy_fn(state.position), state.position"
       ],
-      "execution_count": 70,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -2864,7 +2864,7 @@
         "draw_system(bubble_positions[N_2:], box_size, markersize)\n",
         "finalize_plot((2.0, 1))"
       ],
-      "execution_count": 71,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2906,7 +2906,7 @@
         "\n",
         "box_size, raft_energy, bubble_positions = vec_simulation(diameter, sim_keys)"
       ],
-      "execution_count": 72,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -2930,7 +2930,7 @@
         "\n",
         "format_plot('$D$', '$\\\\langle E\\\\rangle$')"
       ],
-      "execution_count": 73,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2973,13 +2973,13 @@
         "  #   continue\n",
         "  plt.subplot(2, 5, i + 1)\n",
         "  c = min(1, max(0, (E_mean[i] - 0.4) * 4))\n",
-        "  color = [c, 0, 1 - c] \n",
+        "  color = [c, 0, 1 - c]\n",
         "  draw_system(bubble_positions[i, 0, :N_2], box_size[i, 0], d * ms, color=color)\n",
         "  draw_system(bubble_positions[i, 0, N_2:], box_size[i, 0], ms, color=color)\n",
         "\n",
         "finalize_plot((2.5, 1))"
       ],
-      "execution_count": 75,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -3002,7 +3002,7 @@
         "id": "MSXDGgzCDhLG"
       },
       "source": [
-        "Notice that when the diameter of the smaller bubbles is very smaller-than or equal-to that of the larger ones, the structure looks much more hexagonal. However, when the diameter is in-between (where the energy is high) the bubbles end up looking like they are arranged randomly. This is an effect known as the [Jamming transition.](https://) However, could we have found this optimally disordered region without brute force? Let's try to maximize the energy with respect to the diameter, $D$, directly. \n",
+        "Notice that when the diameter of the smaller bubbles is very smaller-than or equal-to that of the larger ones, the structure looks much more hexagonal. However, when the diameter is in-between (where the energy is high) the bubbles end up looking like they are arranged randomly. This is an effect known as the [Jamming transition.](https://) However, could we have found this optimally disordered region without brute force? Let's try to maximize the energy with respect to the diameter, $D$, directly.\n",
         "\n",
         "To do this, we will run short simulation trajectories starting with the positions after minimization that we found above. At the end of the short simulation we will compute the energy of the bubble raft. We will then take the derivative of the energy after the short simulation with respect to the particle diameter.  We're going to make use of the JAX's `grad` function. The function `df_dx = grad(f)` takes a function and returns a new function that computes its gradient with respect to its first argument. Let's now write a shorter simulation function and have it just return the final energy of the system."
       ]
@@ -3031,7 +3031,7 @@
         "\n",
         "  return energy_fn(state)"
       ],
-      "execution_count": 79,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -3052,7 +3052,7 @@
         "dE_dD_fun = grad(short_simulation)\n",
         "dE_dD_fun = jit(vmap(dE_dD_fun, (None, 0, 0)))"
       ],
-      "execution_count": 80,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -3082,7 +3082,7 @@
         "  dE_dD += [dE_dD_fun(d, bubble_positions[i], split)]\n",
         "dE_dD = np.array(dE_dD)"
       ],
-      "execution_count": 81,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -3140,7 +3140,7 @@
         "\n",
         "finalize_plot((1.25, 1))"
       ],
-      "execution_count": 82,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",


### PR DESCRIPTION
The notebook raises exceptions with the current JAX version (0.4.14, as provided by Colab). This is fixed by making two trivial changes, after which the notebook runs without error:

- Import stax and optimizers from `jax.example_libraries` instead of `jax.experimental`.
- In `plot_system`, the color needs to be manually coerced to an `onp.array` (it is passed in the notebook as a list-of-DeviceArrays, which matplotlib chokes on).

(opening the notebook in Colab also seems to have removed some trailing whitespace, which clutters up the diff - apologies!)