### PR TITLE
Update broken URL for Cubuk et al. supplementary data.

### DIFF
--- a/notebooks/neural_networks.ipynb
+++ b/notebooks/neural_networks.ipynb
@@ -224,9 +224,10 @@
       "source": [
         "#@title Download Data\n",
         "\n",
-        "!wget https://aip.scitation.org/doi/suppl/10.1063/1.4990503/suppl_file/supplementary.zip\n",
         "!wget https://raw.githubusercontent.com/google/jax-md/main/examples/models/si_gnn.pickle\n",
-        "!unzip supplementary.zip"
+        "!wget https://pubs.aip.org/jcp/article-supplement/988620/zip/024104_1_supplements\n",
+        "!unzip 024104_1_supplements  # wrapper for `Supplementary.zip`.\n",
+        "!unzip Supplementary.zip"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
The previous data URL `https://aip.scitation.org/doi/suppl/10.1063/1.4990503/suppl_file/supplementary.zip` now seems to lead to an error page, so the notebook as checked in no longer runs.

This change updates the notebook to use the link from the current article page, https://pubs.aip.org/aip/jcp/article/147/2/024104/988620/Representations-in-neural-network-based-empirical. This returns a wrapper zip file containing a `Supplementary.zip` that seems to match the contents of the original `supplementary.zip`, in that with this change the rest of the notebook runs without error.