### PR TITLE
feat(ci): enable pip caching in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          setup.py
     - name: Install dependencies
       run: |
         pip install --upgrade pip


### PR DESCRIPTION
This PR aims to set the `cache` argument to `pip` to enable caching of python packages in the CI. This enables for faster CI runs, thereby helping DX and the contributing experience.