### PR TITLE
Fixes #298

### DIFF
--- a/jax_md/rigid_body.py
+++ b/jax_md/rigid_body.py
@@ -73,7 +73,7 @@ Array = util.Array
 PyTree = Any
 f64 = util.f64
 f32 = util.f32
-KeyArray = random.KeyArray
+KeyArray = jax.Array
 NeighborListFns = partition.NeighborListFns
 ShiftFn = space.ShiftFn
 


### PR DESCRIPTION
In jax 0.4.24 they removed `KeyArray` from `jax.random` (see https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-24-feb-6-2024), the advice is now to just use `jax.Array` instead.

One line fix.  This closes #298.