### PR TITLE
Updating tests for deprecations/errors

### DIFF
--- a/jax_md/_nn/e3nn_layer.py
+++ b/jax_md/_nn/e3nn_layer.py
@@ -212,7 +212,7 @@ import e3nn_jax as e3nn
 from e3nn_jax import Irreps
 from e3nn_jax import IrrepsArray
 from e3nn_jax.legacy import FunctionalFullyConnectedTensorProduct
-from e3nn_jax import FunctionalLinear 
+from e3nn_jax import FunctionalLinear
 from e3nn_jax.utils import vmap
 
 import flax.linen as nn
@@ -223,7 +223,7 @@ import jax.numpy as jnp
 from jax.nn import initializers
 from jax import tree_util
 from jax import jit
-from jax import tree_map
+from jax.tree_util import tree_map
 
 import numpy as onp
 

--- a/jax_md/_nn/gnome.py
+++ b/jax_md/_nn/gnome.py
@@ -19,7 +19,7 @@ import os
 from jax.core import ShapedArray
 from jax import eval_shape
 from jax import random
-from jax import tree_map
+from jax.tree_util import tree_map
 
 import jax.numpy as jnp
 
@@ -92,7 +92,7 @@ def scale_lr_on_plateau(initial_step_size: float,
 
   def update_fn(updates, state, params=None):
     del params
-    updates = jax.tree_map(lambda g: g * state.step_size, updates)
+    updates = jax.tree_util.tree_map(lambda g: g * state.step_size, updates)
     return updates, state
 
   return optax.GradientTransformation(init_fn, update_fn)

--- a/jax_md/_nn/nequip.py
+++ b/jax_md/_nn/nequip.py
@@ -54,7 +54,7 @@ FeaturizerFn = nn_util.FeaturizerFn
 
 get_nonlinearity_by_name = nn_util.get_nonlinearity_by_name
 partial = functools.partial
-tree_map = partial(jax.tree_map, is_leaf=lambda x: isinstance(x, e3nn.IrrepsArray))
+tree_map = partial(jax.tree_util.tree_map, is_leaf=lambda x: isinstance(x, e3nn.IrrepsArray))
 
 # Code
 

--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -35,7 +35,7 @@ from jax import ops
 from jax import jit, vmap, eval_shape
 from jax.core import ShapedArray
 from jax.interpreters import partial_eval as pe
-from jax import tree_map
+from jax.tree_util import tree_map
 import jax.numpy as jnp
 
 from jax_md import space

--- a/jax_md/smap.py
+++ b/jax_md/smap.py
@@ -24,7 +24,8 @@ from operator import mul
 
 import numpy as onp
 
-from jax import lax, ops, vmap, eval_shape, tree_map
+from jax import lax, ops, vmap, eval_shape
+from jax.tree_util import tree_map
 from jax.core import ShapedArray
 from jax.interpreters import partial_eval as pe
 import jax.numpy as jnp
@@ -84,7 +85,7 @@ class ParameterTree:
       mapped functions, these parameters are processed according to the
       mapping.
     mapping: A ParameterTreeMapping object that specifies how the parameters
-      are processed. 
+      are processed.
   """
   tree: PyTree
   mapping: ParameterTreeMapping = dataclasses.static_field()

--- a/jax_md/test_util.py
+++ b/jax_md/test_util.py
@@ -25,7 +25,6 @@ import netCDF4 as nc
 
 import jax.numpy as jnp
 import numpy as onp
-from jax.config import config
 
 import jax
 from jax import dtypes as _dtypes
@@ -168,7 +167,7 @@ class JAXMDTestCase(parameterized.TestCase):
       self.assertDtypesMatch(x, y)
 
   def assertDtypesMatch(self, x, y, *, canonicalize_dtypes=True):
-    if not config.x64_enabled and canonicalize_dtypes:
+    if not jax.config.x64_enabled and canonicalize_dtypes:
       self.assertEqual(_dtypes.canonicalize_dtype(_dtype(x)),
                        _dtypes.canonicalize_dtype(_dtype(y)))
     else:

--- a/jax_md/test_util.py
+++ b/jax_md/test_util.py
@@ -186,8 +186,8 @@ class JAXMDTestCase(parameterized.TestCase):
     def is_finite(x):
       self.assertTrue(jnp.all(jnp.isfinite(x)))
 
-    jax.tree_map(is_finite, x)
-    jax.tree_map(is_finite, y)
+    jax.tree_util.tree_map(is_finite, x)
+    jax.tree_util.tree_map(is_finite, y)
 
     def assert_close(x, y):
       self._assertAllClose(

--- a/jax_md/util.py
+++ b/jax_md/util.py
@@ -16,6 +16,7 @@
 
 from typing import Iterable, Union, Optional, Any
 
+import jax
 from jax.tree_util import register_pytree_node
 from jax.lib import xla_bridge
 import jax.numpy as jnp
@@ -25,7 +26,7 @@ from functools import partial
 
 import numpy as onp
 
-Array = Any
+Array = jnp.ndarray
 PyTree = Any
 
 i16 = jnp.int16

--- a/notebooks/implicit_differentiation.ipynb
+++ b/notebooks/implicit_differentiation.ipynb
@@ -564,9 +564,9 @@
       },
       "source": [
         "# Implicit and explicit differentiation gives the same result.\n",
-        "print(jax.tree_map(jnp.allclose,exp_e,imp_e))\n",
-        "print(jax.tree_map(jnp.allclose,exp_f,imp_f))\n",
-        "print(jax.tree_map(jnp.allclose,exp_g,imp_g))"
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_e,imp_e))\n",
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_f,imp_f))\n",
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_g,imp_g))"
       ],
       "execution_count": 8,
       "outputs": [
@@ -704,9 +704,9 @@
       },
       "source": [
         "# Implicit and explicit differentiation gives the same result.\n",
-        "print(jax.tree_map(jnp.allclose,exp_e,imp_e))\n",
-        "print(jax.tree_map(jnp.allclose,exp_f,imp_f))\n",
-        "print(jax.tree_map(jnp.allclose,exp_g,imp_g))"
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_e,imp_e))\n",
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_f,imp_f))\n",
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_g,imp_g))"
       ],
       "execution_count": 10,
       "outputs": [
@@ -829,16 +829,16 @@
       },
       "source": [
         "# Using neighbor lists also gives the same results.\n",
-        "print(jax.tree_map(jnp.allclose,exp_e,imp_nl_e))\n",
-        "print(jax.tree_map(jnp.allclose,exp_f,imp_nl_f))\n",
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_e,imp_nl_e))\n",
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_f,imp_nl_f))\n",
         "\n",
         "# We cannot directly compare the gradients because by using neighbor lists we \n",
         "# silently assume that the input matrix is symmetric. Thus we compare the upper\n",
         "# triangular part of exp_g to imp_nl_g. Due to this symmetry we also have to \n",
         "# divide exp_g by 2 in order to prevent double counting.\n",
-        "exp_g_triu = jax.tree_map(jnp.triu,exp_g)\n",
-        "imp_nl_g_2 = jax.tree_map(lambda x: x/2, imp_nl_g)\n",
-        "print(jax.tree_map(jnp.allclose,exp_g_triu, imp_nl_g_2))"
+        "exp_g_triu = jax.tree_util.tree_map(jnp.triu,exp_g)\n",
+        "imp_nl_g_2 = jax.tree_util.tree_map(lambda x: x/2, imp_nl_g)\n",
+        "print(jax.tree_util.tree_map(jnp.allclose,exp_g_triu, imp_nl_g_2))"
       ],
       "execution_count": 12,
       "outputs": [

--- a/tests/elasticity_test.py
+++ b/tests/elasticity_test.py
@@ -19,7 +19,7 @@ import numpy as onp
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax.config import config as jax_config
+import jax
 from jax import random
 from jax import jit
 from jax import lax
@@ -34,14 +34,14 @@ from jax_md import elasticity
 from jax_md import test_util
 from jax_md.util import *
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 PARTICLE_COUNT = 64
 NUM_SAMPLES = 2
 SPATIAL_DIMENSION = [2, 3]
 LOWPRESSURE = [True, False]
 
-if jax_config.jax_enable_x64:
+if jax.config.jax_enable_x64:
   DTYPE = [f32, f64]
 else:
   DTYPE = [f32]

--- a/tests/energy_test.py
+++ b/tests/energy_test.py
@@ -20,7 +20,7 @@ from absl.testing import parameterized
 from jax import random
 import jax
 from jax import jit, vmap, grad
-from jax import tree_map
+from jax.tree_util import tree_map
 import jax.numpy as np
 from scipy.io import loadmat
 

--- a/tests/energy_test.py
+++ b/tests/energy_test.py
@@ -17,7 +17,6 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax.config import config
 from jax import random
 import jax
 from jax import jit, vmap, grad
@@ -36,7 +35,7 @@ from jax_md import energy
 from jax_md import partition
 from jax_md.interpolate import spline
 
-config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 # TODO: Replace np by jnp everywhere.
 jnp = np
@@ -49,7 +48,7 @@ UNIT_CELL_SIZE = [7, 8]
 SOFT_SPHERE_ALPHA = [2.0, 2.5, 3.0]
 N_TYPES_TO_TEST = [1, 2]
 
-if config.x64_enabled:
+if jax.config.x64_enabled:
   POSITION_DTYPE = [f32, f64]
 else:
   POSITION_DTYPE = [f32]
@@ -867,7 +866,7 @@ class EnergyTest(test_util.JAXMDTestCase):
     box_size = np.linalg.det(lattice_vectors) ** (1 / 3)
     energy_fn = energy.edip(displacement)
     E = energy_fn(atoms)
-    
+
     if dtype is f64:
       self.assertAllClose(E, dtype(-297.597013492761), atol=1e-5, rtol=2e-8)
     else:

--- a/tests/minimize_test.py
+++ b/tests/minimize_test.py
@@ -19,7 +19,7 @@ import numpy as onp
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax.config import config as jax_config
+import jax
 from jax import random
 from jax import jit
 from jax import lax
@@ -31,14 +31,14 @@ from jax_md import quantity
 from jax_md.util import *
 from jax_md import test_util
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 PARTICLE_COUNT = 10
 OPTIMIZATION_STEPS = 10
 STOCHASTIC_SAMPLES = 10
 SPATIAL_DIMENSION = [2, 3]
 
-if jax_config.jax_enable_x64:
+if jax.config.jax_enable_x64:
   DTYPE = [f32, f64]
 else:
   DTYPE = [f32]

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -17,7 +17,7 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax.config import config as jax_config
+import jax
 from jax import random
 import jax.numpy as np
 
@@ -30,9 +30,9 @@ from jax_md.nn import behler_parrinello as bp
 from jax_md.util import f32, f64
 from jax_md import test_util
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
-if jax_config.jax_enable_x64:
+if jax.config.jax_enable_x64:
   DTYPES = [f32, f64]
 else:
   DTYPES = [f32]
@@ -105,7 +105,7 @@ class SymmetryFunctionTest(test_util.JAXMDTestCase):
     gr_exact = gr(R)
     gr_nbrs = gr_neigh(R, neighbor=nbrs)
 
-    tol = 1e-13 if jax_config.jax_enable_x64 else 1e-6
+    tol = 1e-13 if jax.config.jax_enable_x64 else 1e-6
     self.assertAllClose(gr_exact, gr_nbrs, atol=tol, rtol=tol)
 
   @parameterized.named_parameters(test_util.cases_from_list(
@@ -159,7 +159,7 @@ class SymmetryFunctionTest(test_util.JAXMDTestCase):
     gr_exact = gr(R)
     gr_nbrs = gr_neigh(R, neighbor=nbrs)
 
-    tol = 1e-13 if jax_config.jax_enable_x64 else 1e-6
+    tol = 1e-13 if jax.config.jax_enable_x64 else 1e-6
     self.assertAllClose(gr_exact, gr_nbrs, atol=tol, rtol=tol)
 
   @parameterized.named_parameters(test_util.cases_from_list(

--- a/tests/partition_test.py
+++ b/tests/partition_test.py
@@ -21,7 +21,7 @@ from absl.testing import parameterized
 
 from functools import partial
 
-from jax.config import config as jax_config
+import jax
 
 from jax import random
 import jax.numpy as np
@@ -34,14 +34,14 @@ from jax_md import smap, partition, space, energy, quantity
 from jax_md.util import *
 from jax_md import test_util
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 
 PARTICLE_COUNT = 1000
 STOCHASTIC_SAMPLES = 10
 SPATIAL_DIMENSION = [2, 3]
 
-if jax_config.jax_enable_x64:
+if jax.config.jax_enable_x64:
   POSITION_DTYPE = [f32, f64]
 else:
   POSITION_DTYPE = [f32]
@@ -486,12 +486,12 @@ class NeighborListTest(test_util.JAXMDTestCase):
       disable_cell_list=disable_cell_list,
       mask_self=mask_self,
       format=format)
-    
+
     nbrs = neighbor_fn.allocate(positions)
 
     self.assertFalse(nbrs.did_buffer_overflow)
     self.assertEqual(nbrs.idx.shape, desired_shape)
-    
+
     new_nbrs = nbrs.update(positions + 0.1)
     self.assertFalse(new_nbrs.did_buffer_overflow)
     self.assertEqual(new_nbrs.idx.shape, desired_shape)

--- a/tests/quantity_test.py
+++ b/tests/quantity_test.py
@@ -17,7 +17,7 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax.config import config as jax_config
+import jax
 from jax import random
 import jax.numpy as np
 
@@ -31,7 +31,7 @@ from jax_md import smap
 from jax_md.util import *
 
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 PARTICLE_COUNT = 10
 STOCHASTIC_SAMPLES = 10
@@ -41,7 +41,7 @@ NEIGHBOR_LIST_FORMAT = [partition.Dense,
                         partition.Sparse,
                         partition.OrderedSparse]
 
-DTYPES = [f32, f64] if jax_config.jax_enable_x64 else [f32]
+DTYPES = [f32, f64] if jax.config.jax_enable_x64 else [f32]
 COORDS = ['fractional', 'real']
 
 
@@ -602,7 +602,7 @@ class QuantityTest(test_util.JAXMDTestCase):
 
 
   def test_maybe_downcast(self):
-    if not jax_config.jax_enable_x64:
+    if not jax.config.jax_enable_x64:
       self.skipTest('Maybe downcast only works for float32 mode.')
 
     x = np.array([1, 2, 3], np.float64)

--- a/tests/rigid_body_test.py
+++ b/tests/rigid_body_test.py
@@ -28,7 +28,6 @@ from jax import random
 from jax import lax
 from jax import test_util as jtu
 
-from jax.config import config as jax_config
 import jax.numpy as jnp
 
 from jax_md import quantity
@@ -43,7 +42,7 @@ from jax_md import minimize
 
 from functools import partial
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 
 
@@ -63,7 +62,7 @@ BROWNIAN_PARTICLE_COUNT = 8000
 BROWNIAN_DYNAMICS_STEPS = 8000
 
 DTYPE = [f32]
-if jax_config.jax_enable_x64:
+if jax.config.jax_enable_x64:
   DTYPE += [f64]
 
 

--- a/tests/simulate_test.py
+++ b/tests/simulate_test.py
@@ -24,7 +24,7 @@ from jax import vmap
 from jax import random
 from jax import lax
 
-from jax.config import config as jax_config
+import jax
 import jax.numpy as np
 
 from jax_md import quantity
@@ -40,7 +40,7 @@ from jax_md.util import *
 
 from functools import partial
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 
 PARTICLE_COUNT = 1000
@@ -57,7 +57,7 @@ BROWNIAN_PARTICLE_COUNT = 8000
 BROWNIAN_DYNAMICS_STEPS = 8000
 
 DTYPE = [f32]
-if jax_config.jax_enable_x64:
+if jax.config.jax_enable_x64:
   DTYPE += [f64]
 
 
@@ -699,7 +699,7 @@ class SimulateTest(test_util.JAXMDTestCase):
       tol = 5e-4 if dtype is f32 else 1e-6
       self.assertAllClose(invariant(state.momentum, state.mass), initial, rtol=tol)
       self.assertEqual(state.position.dtype, dtype)
-  
+
   @parameterized.named_parameters(test_util.cases_from_list(
       {
           'testcase_name': '_dim={}_dtype={}'.format(dim, dtype.__name__),

--- a/tests/smap_test.py
+++ b/tests/smap_test.py
@@ -17,7 +17,7 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax.config import config as jax_config
+import jax
 
 from jax import random
 import jax.numpy as np
@@ -30,7 +30,7 @@ from jax_md import smap, space, energy, quantity, partition, dataclasses
 from jax_md.util import *
 from jax_md import test_util
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 test_util.update_test_tolerance(f32_tol=5e-6, f64_tol=1e-14)
 
@@ -43,7 +43,7 @@ NEIGHBOR_LIST_FORMAT = [partition.Dense,
 
 NEIGHBOR_LIST_PARTICLE_COUNT = 100
 
-if jax_config.jax_enable_x64:
+if jax.config.jax_enable_x64:
   POSITION_DTYPE = [f32, f64]
 else:
   POSITION_DTYPE = [f32]

--- a/tests/space_test.py
+++ b/tests/space_test.py
@@ -17,7 +17,7 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax.config import config as jax_config
+import jax
 from jax import random
 import jax.numpy as jnp
 
@@ -31,7 +31,7 @@ from unittest import SkipTest
 
 test_util.update_test_tolerance(5e-5, 5e-13)
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 PARTICLE_COUNT = 10
 STOCHASTIC_SAMPLES = 10
@@ -39,7 +39,7 @@ SHIFT_STEPS = 10
 SPATIAL_DIMENSION = [2, 3]
 BOX_FORMATS = ['scalar', 'vector', 'matrix']
 
-if jax_config.jax_enable_x64:
+if jax.config.jax_enable_x64:
   POSITION_DTYPE = [f32, f64]
 else:
   POSITION_DTYPE = [f32]

--- a/tests/tpu_test.py
+++ b/tests/tpu_test.py
@@ -34,9 +34,8 @@ import numpy as onp
 
 from jax_md import tpu
 
-from jax.config import config as jax_config
 
-jax_config.parse_flags_with_absl()
+jax.config.parse_flags_with_absl()
 
 update_test_tolerance(5e-5, 1e-7)
 
@@ -225,9 +224,9 @@ class ConvolutionalMDTest(test_util.JAXMDTestCase):
     jmd_state = simulate.NVEState(R, V, force_fn(R), mass)
     def jmd_step_fn(state, i):
       return jmd_apply_fn(state), i
-    jax_config.update('jax_numpy_rank_promotion', 'warn')
+    jax.config.update('jax_numpy_rank_promotion', 'warn')
     new_jmd_state, _ = lax.scan(jmd_step_fn, jmd_state, np.arange(steps))
-    jax_config.update('jax_numpy_rank_promotion', 'raise')
+    jax.config.update('jax_numpy_rank_promotion', 'raise')
 
     # compare outputs
     grid_positions, grid_aux = tpu.from_grid(new_state.position, new_state.velocity)


### PR DESCRIPTION
This PR updates the deprecations in jax that are causing warnings or errors on the CI test runs. Specifically:

`from jax.config import config` -> `jax.config`

and 

`jax.tree_map` -> `jax.tree_util.tree_map`

Four of the tests are still failing on my local unit test runs with bool tracer conversion errors. The pytest output for one of the tests is below. If you have some hints at why it's failing, I'll update those as well so the CI should pass.

```python
____________________________________________________________________________ RigidBodyTest.test_nve_2d_neighbor_list_multi_atom_species_dtype=float32 ____________________________________________________________________________
[gw3] linux -- Python 3.9.19 /home/ryan/miniforge3/envs/jax_md/bin/python
jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

The above exception was the direct cause of the following exception:

self = <rigid_body_test.RigidBodyTest testMethod=test_nve_2d_neighbor_list_multi_atom_species_dtype=float32>, dtype = <class 'jax.numpy.float32'>

    @parameterized.named_parameters(test_util.cases_from_list(
        {
            'testcase_name': '_dtype={}'.format(dtype.__name__),
            'dtype': dtype
        } for dtype in DTYPE))
    def test_nve_2d_neighbor_list_multi_atom_species(self, dtype):
      N = PARTICLE_COUNT
      box_size = quantity.box_size_at_number_density(N, 0.1, 2)
    
      displacement, shift = space.periodic(box_size)
    
      key = random.PRNGKey(0)
    
      key, pos_key, angle_key = random.split(key, 3)
    
      R = box_size * random.uniform(pos_key, (N, 2), dtype=dtype)
      angle = random.uniform(angle_key, (N,), dtype=dtype) * jnp.pi * 2
    
      body = rigid_body.RigidBody(R, angle)
      shape = rigid_body.square.set(point_species=jnp.array([0, 1, 0, 1]))
    
      neighbor_fn, energy_fn = energy.soft_sphere_neighbor_list(displacement,
                                                                box_size)
      neighbor_fn, energy_fn = rigid_body.point_energy_neighbor_list(energy_fn,
                                                                     neighbor_fn,
                                                                     shape)
      init_fn, step_fn = simulate.nve(energy_fn, shift)
    
      step_fn = jit(step_fn)
    
      @jit
      def total_energy(state, nbrs):
        pos = state.position
        return (energy_fn(pos, neighbor=nbrs) +
                simulate.kinetic_energy(state))
    
      nbrs = neighbor_fn.allocate(body)
>     state = init_fn(key, body, 1e-3, mass=shape.mass(), neighbor=nbrs)

tests/rigid_body_test.py:301: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
jax_md/simulate.py:286: in init_fn
    force = force_fn(R, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

R = RigidBody(center=Traced<ShapedArray(float32[40,2])>with<DynamicJaxprTrace(level=1/0)>, orientation=Traced<ShapedArray(float32[40])>with<DynamicJaxprTrace(level=1/0)>)
kwargs = {'neighbor': <[UnexpectedTracerError('Encountered an unexpected tracer. A function transformed by JAX had a side effec...s.io/en/latest/errors.html#jax.errors.UnexpectedTracerError') raised in repr()] NeighborList object at 0x74182340dd30>}

    def force_fn(R, **kwargs):
      nonlocal _force_fn
      if _force_fn is None:
>       out_shaped = eval_shape(energy_or_force_fn, R, **kwargs)
E       jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[]..
E       The error occurred while tracing the function init_fn at /home/ryan/repos/jax-md/jax_md/simulate.py:284 for jit. This value became a tracer due to JAX operations on these lines:
E       
E         operation a:bool[] = eq b c
E           from line /home/ryan/repos/jax-md/jax_md/quantity.py:82 (force_fn)
E       See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerBoolConversionError

jax_md/quantity.py:82: TracerBoolConversionError
```



