### PR TITLE
Fix to #277 and update Python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.11.0

--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,11 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     description='Differentiable, Hardware Accelerated, Molecular Dynamics',
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     classifiers=[
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: MacOS',
         'Operating System :: POSIX :: Linux',

--- a/tests/rigid_body_test.py
+++ b/tests/rigid_body_test.py
@@ -18,6 +18,7 @@ import functools
 
 from absl.testing import absltest
 from absl.testing import parameterized
+import pytest
 
 import numpy as onp
 
@@ -71,6 +72,12 @@ if jax_config.jax_enable_x64:
 def rand_quat(key, dtype):
   return rigid_body.random_quaternion(key, dtype)
 
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests(tmpdir):
+  # This is a fixture that runs before and after each test.
+  # This fixes issue 227 (https://github.com/jax-md/jax-md/issues/277)
+  yield # this is where the testing happens
+  jax.clear_caches()
 
 # pylint: disable=invalid-name
 class RigidBodyTest(test_util.JAXMDTestCase):

--- a/tests/rigid_body_test.py
+++ b/tests/rigid_body_test.py
@@ -313,15 +313,7 @@ class RigidBodyTest(test_util.JAXMDTestCase):
       nbrs = nbrs.update(state.position)
       state = step_fn(state, neighbor=nbrs)
       return state, nbrs
-    try:
-      state, nbrs = lax.fori_loop(0, DYNAMICS_STEPS, step, (state, nbrs))
-    except jax.errors.ConcretizationTypeError:
-      # NOTE: for some weird reason, this test fails if it is run after test_nve_2d_neighbor_list.
-      # However, this test does not fail if it is run by itself.
-      # This is probably due to some weird JIT interaction between the two tests.
-      # The same happens to test_nve_2d_neighbor_list if this test is run first.
-      # TODO: figure out why this happens.
-      self.skipTest('Skipping test due to concretization error.')
+    state, nbrs = lax.fori_loop(0, DYNAMICS_STEPS, step, (state, nbrs))
     E_final = total_energy(state, nbrs)
 
     tol = 5e-8 if dtype == f64 else 5e-5


### PR DESCRIPTION
This pull request fixed the TracerBoolConversionError bug as documented in #277 (clearing the JAX cache between tests seems to be the trick).
Moreover, the minimal Python version was increased to 3.10 to conform to [JAX's minimal version](https://github.com/google/jax/commit/945fde41e49a7cdce67ade1622b706c960120db4).