### PR TITLE
fix: import numpy.typing for numpy<2 compatibility

### DIFF
--- a/jax_md/_nn/mace/model_builder.py
+++ b/jax_md/_nn/mace/model_builder.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import jax.numpy as jnp
 import numpy as np
+import numpy.typing
 from e3nn_jax import Irreps
 
 from flax import nnx


### PR DESCRIPTION
Fixes #417

## Problem

`np.typing.XXX` is only accessible on numpy < 2.0 if `numpy.typing` has been explicitly imported earlier. Today this is masked by the dependency graph — the `mace` group forces `jax>=0.10` → `numpy>=2`, and without the `mace` group the module fails earlier on a missing `mace_jax` import (details in the issue). However, the annotation's resolution still relies on numpy >= 2.0's lazy `__getattr__` with no explicit import and no declared numpy floor, so the failure mode resurfaces if mace-jax's constraints are ever relaxed. This PR closes that robustness gap.

## Fix

**File**: `jax_md/_nn/mace/model_builder.py`

Add the explicit import right after the numpy import:

```diff
  import numpy as np
+ import numpy.typing
```

## Verification

- Verified the failure mechanism in isolation on numpy 1.26.4: `np.typing.DTypeLike` raises `AttributeError: module 'numpy' has no attribute 'typing'` unless `numpy.typing` has been imported first; with the import added, the expression resolves successfully.
- Full-environment check (clean venv, python 3.12): with numpy<2, `pip install jax-md` (core, no `mace` group) resolves to numpy 1.26.4 + jax 0.6.2 and `import jax_md` succeeds. The affected module fails earlier on `ModuleNotFoundError: No module named 'mace_jax'` when the `mace` dependency group is absent. Conversely, installing the `mace` group forces `jax>=0.10` → `numpy>=2` via mace-jax's own constraints, where the annotation resolves natively. So today the annotation only evaluates on numpy<2 in legacy or hand-built environments that predate mace-jax's `jax>=0.10` constraint.
- The change only adds an import — no behavioral change on numpy >= 2. It is a robustness improvement that future-proofs the module if mace-jax's constraints are ever relaxed.